### PR TITLE
Fix crash when robot is offline

### DIFF
--- a/fleet_adapter_ecobot/fleet_adapter_ecobot.py
+++ b/fleet_adapter_ecobot/fleet_adapter_ecobot.py
@@ -169,7 +169,7 @@ def initialize_fleet(config_yaml, nav_graph_path, node, server_uri, args):
                     api = EcobotAPI(robot_config['base_url'], robot_config['cleaning_task_prefix'])
 
                 if not api.online():
-                    node.get_logger().error(f"Robot [{robot_map_name}] is offline")
+                    node.get_logger().error(f"Robot [{robot_name}] is offline")
                     continue
 
                 robot_map_name = api.current_map()


### PR DESCRIPTION
A typo in the printout when a robot is offline causes the fleet adapter to crash with the following error when going into that codepath:

```
Exception in thread Thread-1 (_add_fleet_robots):
Traceback (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/opt/rmf/install/fleet_adapter_ecobot/lib/python3.10/site-packages/fleet_adapter_ecobot/fleet_adapter_ecobot.py", line 172, in _add_fleet_robots
    node.get_logger().error(f"Robot [{robot_map_name}] is offline")
UnboundLocalError: local variable 'robot_map_name' referenced before assignment
```

The variable should really be `robot_name`, not `robot_map_name` and this PR fixes it