### PR TITLE
Add configurable cleaning mode feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ ros2 run rmf_demos_tasks dispatch_patrol -p pantry
 
 Send the robot to clean an area. This custom clean task is created by composing `go_to_place` and custom `perform_action`.
 ```bash
-ros2 run rmf_demos_tasks dispatch_action -s patrol_D2 -a clean -ad '{ "clean_task_name": "clean_hallway" }'
+ros2 run rmf_demos_tasks dispatch_action -s patrol_D2 -a clean -ad '{ "clean_task_name": "clean_hallway", "clean_mode": "heavy_cleaning" }'
 ```
 
 ### Show overlayed ecobot map

--- a/fleet_adapter_ecobot/EcobotCommandHandle.py
+++ b/fleet_adapter_ecobot/EcobotCommandHandle.py
@@ -446,7 +446,11 @@ class EcobotCommandHandle(adpt.RobotCommandHandle):
             self.action_category = category
             if (category == "clean"):
                 attempts = 0
-                self.api.set_cleaning_mode(self.config['active_cleaning_config'])
+                if 'clean_mode' in description:
+                    clean_mode = description['clean_mode']
+                else:
+                    clean_mode = self.config['active_cleaning_config']
+                self.api.set_cleaning_mode(clean_mode)
                 # Will try to make max 3 attempts to start the clean task
                 while True:
                     self.node.get_logger().info(


### PR DESCRIPTION
Signed-off-by: Kai Wen Lum <lum_kai_wen@artc.a-star.edu.sg>

## New feature implementation

### Implemented feature

This pull request fixes #11 

### Implementation description

This implementation checks if there is a `clean_mode` attribute in the `perform_action` description for the clean task. If it exists, the cleaning_mode would be set to that otherwise the `active_cleaning_mode` would be used as the default.